### PR TITLE
Expose IO Utilities

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -47,7 +47,9 @@ ghc-options:
 
 library:
   source-dirs: src
-  exposed-modules: Data.BlockDevice
+  exposed-modules:
+    - Data.BlockDevice
+    - System.BlockDevice
 
 tests:
   hlsblk-test:


### PR DESCRIPTION
Add `System.BlockDevice` module to the exposed-modules.