### PR TITLE
Allow Flags To Be Passed For lsblk Call

### DIFF
--- a/hlsblk.cabal
+++ b/hlsblk.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4602f80a78d250de24ddbb360b6da3dd109bf3ba8a70e1fb01da99f3ee91e308
+-- hash: d6eeb5986d41fef65e2fd0ddcb3978f71bdb3896f43017dabb54b19867fcf9e5
 
 name:           hlsblk
 version:        0.1.0.0
@@ -42,6 +42,7 @@ library
     , base >=4.7 && <5
     , containers
     , hashable
+    , mtl
     , process-extras
     , scientific
     , text
@@ -65,6 +66,7 @@ test-suite hlsblk-test
     , containers
     , hashable
     , hlsblk
+    , mtl
     , process-extras
     , scientific
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -17,6 +17,7 @@ dependencies:
 - attoparsec
 - containers
 - hashable
+- mtl
 - process-extras
 - scientific
 - text

--- a/src/System/BlockDevice.hs
+++ b/src/System/BlockDevice.hs
@@ -1,13 +1,25 @@
-module System.BlockDevice where
+module System.BlockDevice
+  ( defaultFlags
+  , listBlockDevices
+  , listBlockDevices'
+  , Error(..)
+  , errorMessage
+  , errorMessage'
+  ) where
 
-import Control.Applicative (Applicative(..))
 import Control.Monad (return)
-import Data.Either (Either(..))
-import Data.Function (($))
+import Control.Monad.Except (MonadError(..), runExceptT)
+import Control.Monad.IO.Class (MonadIO(..))
+import Data.Bool (otherwise)
+import Data.Either (Either(..), either)
+import Data.Eq (Eq(..))
+import Data.Function (($), (.))
+import Data.Int (Int)
 import Data.Maybe (maybe)
 import Data.Monoid ((<>), mempty)
 import Data.String (String)
 import Prelude (FilePath)
+import System.Exit (ExitCode(..))
 import System.IO (IO)
 import System.Process.Text (readProcessWithExitCode)
 import Text.Show (Show(..))
@@ -15,28 +27,91 @@ import Text.Show (Show(..))
 import qualified Data.Aeson as DA
 import qualified Data.BlockDevice as DB
 import qualified Data.HashMap.Strict as DHS
+import qualified Data.Set as DS
 import qualified Data.Text as DT
 import qualified Data.Text.Encoding as DTE
 
-listBlockDevices' :: IO (Either String [DB.BlockDevice])
-listBlockDevices' = do
-  (_, out, _) <-
-    readProcessWithExitCode lsblkPath ["-J", "-a", "-O", "-b"] mempty
-  return $ do
-    value <- DA.eitherDecodeStrict' $ DTE.encodeUtf8 out
-    value' <- unwrap value
-    case DA.fromJSON value' of
-      DA.Error err -> Left err
-      DA.Success a -> Right a
+defaultFlags :: DS.Set DT.Text
+defaultFlags = DS.fromList ["-J", "-a", "-O", "-b"]
+
+listBlockDevices ::
+     (MonadError Error m, MonadIO m) => DS.Set DT.Text -> m [DB.BlockDevice]
+listBlockDevices flags =
+  let flags' = DS.toList . DS.map DT.unpack $ DS.insert jsonFlag flags
+   in do (ec, out, err) <-
+           liftIO $ readProcessWithExitCode lsblkPath flags' mempty
+         guardExitCode ec err
+         value <- stdoutToJson out
+         value' <- unwrap value
+         jsonToBlockDevice value'
+
+listBlockDevices' :: DS.Set DT.Text -> IO (Either Error [DB.BlockDevice])
+listBlockDevices' flags =
+  runExceptT $ catchError (listBlockDevices flags) throwError
+
+data Error where
+  UnexpectedJsonValue :: DA.Value -> Error
+  InvalidBlockDeviceValue :: DA.Value -> String -> Error
+  StdOutIsNotValidJson :: DT.Text -> String -> Error
+  NonzeroExitCode :: Int -> DT.Text -> Error
+
+deriving instance Show Error
+
+deriving instance Eq Error
+
+errorMessage :: Error -> DT.Text
+errorMessage UnexpectedJsonValue {} =
+  "Unexpected initial JSON value. lsblk is expected to emit a single object, with a single key \"blockdevices\", the value of which is a JSON array of blockdevice values."
+errorMessage (NonzeroExitCode ec err) =
+  "lsblk exited with a non-zero exit code: " <> (DT.pack . show $ ec) <>
+  stdErrMessageOrNothing err
+errorMessage (InvalidBlockDeviceValue value err) =
+  "The value found in the output JSON for \"blockdevice\" was malformed\n" <>
+  "Found: " <>
+  DT.pack (show value) <>
+  "\n" <>
+  "Aeson Error: " <>
+  DT.pack err
+errorMessage (StdOutIsNotValidJson stdout err) =
+  "lsblk did not output valid JSON to stdout.\n" <> "Aeson Error: " <>
+  DT.pack err <>
+  "\n" <>
+  "StdOut: " <>
+  stdout
+
+errorMessage' :: Error -> String
+errorMessage' = DT.unpack . errorMessage
+
+guardExitCode :: (MonadError Error m) => ExitCode -> DT.Text -> m ()
+guardExitCode (ExitFailure i) err = throwError $ NonzeroExitCode i err
+guardExitCode _ _ = return ()
+
+stdoutToJson :: (MonadError Error m) => DT.Text -> m DA.Value
+stdoutToJson out =
+  either
+    (throwError . StdOutIsNotValidJson out)
+    return
+    (DA.eitherDecodeStrict' $ DTE.encodeUtf8 out)
+
+jsonToBlockDevice :: (MonadError Error m) => DA.Value -> m [DB.BlockDevice]
+jsonToBlockDevice v =
+  case DA.fromJSON v of
+    DA.Error err -> throwError $ InvalidBlockDeviceValue v err
+    DA.Success bd -> return bd
+
+jsonFlag :: DT.Text
+jsonFlag = "-J"
+
+stdErrMessageOrNothing :: DT.Text -> DT.Text
+stdErrMessageOrNothing err
+  | DT.length err == 0 = ""
+  | otherwise = "\nStdErr: " <> err
 
 lsblkPath :: FilePath
 lsblkPath = "/bin/lsblk"
 
-unwrap :: DA.Value -> Either String DA.Value
-unwrap (DA.Object o) =
+unwrap :: (MonadError Error m) => DA.Value -> m DA.Value
+unwrap v@(DA.Object o) =
   let key = "blockdevices"
-   in maybe
-        (Left $ "Unable to find key: " <> DT.unpack key)
-        pure
-        (DHS.lookup key o)
-unwrap other = Left $ "Expected JSON Object, got: " <> show other
+   in maybe (throwError $ UnexpectedJsonValue v) return (DHS.lookup key o)
+unwrap other = throwError $ UnexpectedJsonValue other


### PR DESCRIPTION
* Allow the caller to pass a set of flags to the lsblk call, but always ensure the -J flag for JSON is present.
* Cleanup the `System.BlockDevice` functions.
    * Add error types.
    * Use MonadError and MonadIO, providing an `IO Either` based fallback.